### PR TITLE
created a new method of tracking redeemed keys, unique per platform

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,13 @@ mkdir -p ./data
 
 ## Usage
 
+# ⚠️ Database Change Notice
+
+**As of the 9/18/2025 version, the way redeemed keys are tracked has changed.**  
+Redemption status is now tracked in a separate table for each key and platform combination.  
+**On first run after upgrade, all keys will be retried to ensure the database is properly marked. This may take a long time if you have a large key database.**  
+This is expected and only happens once; subsequent runs will be fast.
+
 You can now specify exactly which platforms should redeem which games' SHiFT codes using the `--redeem` argument.  
 **Recommended:** Use `--redeem` for fine-grained control.  
 **Legacy:** You can still use `--games` and `--platforms` together, but a warning will be printed and all games will be redeemed on all platforms.

--- a/Readme.md
+++ b/Readme.md
@@ -53,8 +53,11 @@ mkdir -p ./data
 
 **As of the 9/18/2025 version, the way redeemed keys are tracked has changed.**  
 Redemption status is now tracked in a separate table for each key and platform combination.  
+
 **On first run after upgrade, all keys will be retried to ensure the database is properly marked. This may take a long time if you have a large key database.**  
 This is expected and only happens once; subsequent runs will be fast.
+
+## Usage Instructions
 
 You can now specify exactly which platforms should redeem which games' SHiFT codes using the `--redeem` argument.  
 **Recommended:** Use `--redeem` for fine-grained control.  

--- a/migrations.py
+++ b/migrations.py
@@ -46,7 +46,7 @@ def register(version: int):
 
     def wrap(func):
         @wraps(func)
-        def wrapper(conn):
+        def wrapper(conn, *args, **kwargs):  # Accept extra arguments for compatibility
             try:
                 if func(conn):
                     conn.cursor().execute("PRAGMA user_version = {}".format(version))

--- a/query.py
+++ b/query.py
@@ -474,7 +474,7 @@ def update_keys():
 
     return keys
 
-
+db = Database()
 db = Database()
     for game, count in sorted(counts.items()):
         _L.info(f"Got {count} new keys for {known_games[game]}")

--- a/query.py
+++ b/query.py
@@ -472,3 +472,6 @@ def update_keys():
         _L.info(f"Got {count} new keys for {known_games[game]}")
 
     return keys
+
+
+db = Database()

--- a/query.py
+++ b/query.py
@@ -22,8 +22,16 @@
 import re
 import sqlite3
 from os import makedirs, path
-from typing import (Callable, ContextManager, Dict, Generic, Iterable,
-                    Iterator, Optional, TypeVar)
+from typing import (
+    Callable,
+    ContextManager,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    Optional,
+    TypeVar,
+)
 
 import requests
 
@@ -31,6 +39,7 @@ from common import _L, DIRNAME
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
+
 
 class SymmetricDict(Dict[_KT, _VT], Generic[_KT, _VT]):
     class ValueOverlapError(Exception):
@@ -46,7 +55,9 @@ class SymmetricDict(Dict[_KT, _VT], Generic[_KT, _VT]):
         ret = dict.__setitem__(self, k, v)
 
         if v in self.inv and self.inv[v] != k:
-            raise SymmetricDict.ValueOverlapError(f"Key `{v}` already exists in inverted dict!")
+            raise SymmetricDict.ValueOverlapError(
+                f"Key `{v}` already exists in inverted dict!"
+            )
 
         self.inv[v] = k
         return ret
@@ -61,28 +72,32 @@ class SymmetricDict(Dict[_KT, _VT], Generic[_KT, _VT]):
             del ret[arg]
         return ret
 
+
 ### games used to help find the correct shift redemption forms
-known_games = SymmetricDict({
-    "bl1":  "Borderlands: Game of the Year Edition",
-    "bl2":  "Borderlands 2",
-    "bl3":  "Borderlands 3",
-    "bl4":  "Borderlands 4",
-    "blps": "Borderlands: The Pre-Sequel",
-    "ttw":  "Tiny Tina's Wonderland",
-    "gdfll": "Godfall",
-})
+known_games = SymmetricDict(
+    {
+        "bl1": "Borderlands: Game of the Year Edition",
+        "bl2": "Borderlands 2",
+        "bl3": "Borderlands 3",
+        "bl4": "Borderlands 4",
+        "blps": "Borderlands: The Pre-Sequel",
+        "ttw": "Tiny Tina's Wonderland",
+        "gdfll": "Godfall",
+    }
+)
 
 ### platforms that are used to find the correct input values in the shift redemption forms
-known_platforms = SymmetricDict({
-    "steam":     "steam",
-    "epic":      "epic",
-    "psn":       "playstation",
-    "xboxlive":  "xbox",
-    "nintendo":  "nintendo",
-    "stadia":    "", # this one could be a substring
-    "universal": "universal"
-})
-
+known_platforms = SymmetricDict(
+    {
+        "steam": "steam",
+        "epic": "epic",
+        "psn": "playstation",
+        "xboxlive": "xbox",
+        "nintendo": "nintendo",
+        "stadia": "",  # this one could be a substring
+        "universal": "universal",
+    }
+)
 
 
 spaces = re.compile(r"\s")
@@ -90,6 +105,7 @@ r_word_chars = re.compile(r"(the|[^a-z0-9])", re.IGNORECASE)
 lowercase_chars = re.compile(r"[a-z]")
 vowels = re.compile(r"[aeiou]", re.IGNORECASE)
 r_golden_keys = re.compile(r"^(\d+)?.*(gold|skelet).*", re.IGNORECASE)
+
 
 def print_banner(data):
     lines = []
@@ -100,11 +116,10 @@ def print_banner(data):
         lines.append("@ https://shift.orcicorn.com/shift-code/")
 
     longest_line = max(len(line) for line in lines) + 2
-    banner = "\n".join(f"{line: ^{longest_line}}"
-                       for line in lines)
+    banner = "\n".join(f"{line: ^{longest_line}}" for line in lines)
     txt = " autoshift by @Fabbi "
     banner = f"{txt:=^{longest_line}}\n{banner}\n"
-    banner += "="*longest_line
+    banner += "=" * longest_line
     _L.info(f"\r\033[1;5;31m{banner}\n")
 
 
@@ -128,6 +143,7 @@ def get_short_game_key(game: str) -> str:
         db.saw_game(ret, game)
     return ret
 
+
 def get_short_platform_key(platform: str) -> str:
     if platform.lower() in known_platforms.inv:
         return known_platforms.inv[platform.lower()]
@@ -147,15 +163,29 @@ def get_short_platform_key(platform: str) -> str:
     if not platform:
         # didn't find a possible replacement
         platform = platform.lower()
-        _L.error(f"Didn't understand platform `{platform}`. "
-                 "Please contact the developer @ github.com/Fabbi")
+        _L.error(
+            f"Didn't understand platform `{platform}`. "
+            "Please contact the developer @ github.com/Fabbi"
+        )
 
     return platform
 
 
 class Key:
-    __slots__ = ("id", "reward", "code", "game", "platform", "redeemed",
-                 "type", "archived", "expires", "link", "expired")
+    __slots__ = (
+        "id",
+        "reward",
+        "code",
+        "game",
+        "platform",
+        "redeemed",
+        "type",
+        "archived",
+        "expires",
+        "link",
+        "expired",
+    )
+
     def __init__(self, **kwargs):
         self.redeemed = False
         self.id = None
@@ -167,16 +197,21 @@ class Key:
         return self
 
     def copy(self):
-        return Key(**{k: getattr(self, k)
-                      for k in self.__slots__
-                      if hasattr(self, k)})
+        return Key(**{k: getattr(self, k) for k in self.__slots__ if hasattr(self, k)})
 
-    def __str__(self): # noqa
+    def __str__(self):  # noqa
         return "Key({})".format(
-            ", ".join([str(getattr(self, k))
-                       for k in ("id", "reward", "code", "game", "platform", "redeemed")]))
-    def __repr__(self): # noqa
+            ", ".join(
+                [
+                    str(getattr(self, k))
+                    for k in ("id", "reward", "code", "game", "platform", "redeemed")
+                ]
+            )
+        )
+
+    def __repr__(self):  # noqa
         return str(self)
+
 
 class Database(ContextManager):
     __conn: sqlite3.Connection
@@ -239,17 +274,19 @@ class Database(ContextManager):
             return
 
         makedirs(path.join(DIRNAME, "data"), exist_ok=True)
-        self.__conn = sqlite3.connect(path.join(DIRNAME, "data", "keys.db"),
-                            detect_types=sqlite3.PARSE_DECLTYPES)
+        self.__conn = sqlite3.connect(
+            path.join(DIRNAME, "data", "keys.db"), detect_types=sqlite3.PARSE_DECLTYPES
+        )
         self.__conn.row_factory = sqlite3.Row
         self.__c = self.__conn.cursor()
 
-        self.__c.execute("CREATE TABLE IF NOT EXISTS keys "
-                "(id INTEGER primary key, description TEXT, "
-                "key TEXT, platform TEXT, game TEXT, redeemed INTEGER)")
+        self.__c.execute(
+            "CREATE TABLE IF NOT EXISTS keys "
+            "(id INTEGER primary key, description TEXT, "
+            "key TEXT, platform TEXT, game TEXT, redeemed INTEGER)"
+        )
         self.commit()
         self.__open = True
-
 
     def close_db(self):
         if self.__open:
@@ -257,24 +294,25 @@ class Database(ContextManager):
             self.__conn.close()
             self.__open = False
 
-
     def insert(self, key: Key):
         """Insert key"""
-
-        el = self.execute("""SELECT * FROM keys
+        el = self.execute(
+            """SELECT * FROM keys
                     WHERE platform = ?
                     AND code = ?
                     AND game = ?""",
-                    (key.platform, key.code, key.game))
+            (key.platform, key.code, key.game),
+        )
         if el.fetchone():
             return None
         _L.debug(f"== inserting {key.game} Key '{key.code}' for {key.platform} ==")
-        self.execute("INSERT INTO keys(reward, code, platform, game, redeemed) "
-                     "VAlUES (?,?,?,?,0)",
-                     (key.reward, key.code, key.platform, key.game))
+        self.execute(
+            "INSERT INTO keys(reward, code, platform, game) "
+            "VALUES (?,?,?,?)",
+            (key.reward, key.code, key.platform, key.game),
+        )
         self.commit()
         return key
-
 
     def get_keys(self, platform, game, all_keys=False):
         """Get all (unredeemed) keys of given platform and game"""
@@ -290,21 +328,19 @@ class Database(ContextManager):
             params.append(game)
             kw = " AND" if platform else " WHERE"
             cmd += f"{kw} game=?"
+        # Only filter out redeemed if not all_keys
         if not all_keys:
             kw = " AND" if (platform or game) else " WHERE"
-            cmd += f"{kw} redeemed=0"
+            cmd += f"""{kw} id NOT IN (
+                SELECT key_id FROM redeemed_keys
+            )"""
 
         cmd += " ORDER BY id DESC"
         ex = self.execute(cmd, params)
 
-        # keys = []
         row: sqlite3.Row
         for row in ex.fetchall():
-            yield Key(**{k:row[k] for k in row.keys()})
-            # keys.append(Key(*row))
-
-        # return keys
-
+            yield Key(**{k: row[k] for k in row.keys()})
 
     def get_special_keys(self, platform, game):
         keys = self.get_keys(platform, game)
@@ -315,7 +351,6 @@ class Database(ContextManager):
                 num += 1
                 ret.append(k)
         return num, ret
-
 
     def get_golden_keys(self, platform, game, all_keys=False):
         keys = self.get_keys(platform, game, all_keys)
@@ -328,27 +363,34 @@ class Database(ContextManager):
                 ret.append(k)
         return num, ret
 
-
     def set_redeemed(self, key):
-        key.redeemed = 1
-        self.execute("UPDATE keys SET redeemed=1 WHERE id=(?)", (key.id, ))
+        # Mark as redeemed for this key id and platform
+        self.execute(
+            "INSERT OR IGNORE INTO redeemed_keys (key_id, platform) VALUES (?, ?)",
+            (key.id, key.platform)
+        )
         self.commit()
 
     def saw_game(self, short, name):
         self.execute("INSERT into seen_games(key, name) VALUES (?, ?)", (short, name))
         self.commit()
+
     def saw_platform(self, short, name):
-        self.execute("INSERT into seen_platforms(key, name) VALUES (?, ?)", (short, name))
+        self.execute(
+            "INSERT into seen_platforms(key, name) VALUES (?, ?)", (short, name)
+        )
         self.commit()
 
 
-
 special_key_handler: dict[str, Callable[[Key], list[Key]]] = {
-    "Borderlands 2 and 3": lambda key: [key.copy().set(game="Borderlands 2"),
-                                   key.set(game="Borderlands 3")],
-    "Borderlands": lambda key: [key.set(game="Borderlands 1")]
+    "Borderlands 2 and 3": lambda key: [
+        key.copy().set(game="Borderlands 2"),
+        key.set(game="Borderlands 3"),
+    ],
+    "Borderlands": lambda key: [key.set(game="Borderlands 1")],
     # "Universal": lambda key: (key.copy().set(platform=plat) for plat in platforms)
 }
+
 
 def flatten(itr: Iterable[Iterable[_VT]]) -> Iterator[_VT]:
     for el in itr:
@@ -359,10 +401,11 @@ def progn(*args: _VT) -> _VT:
     *_, lastArg = args
     return lastArg
 
+
 def parse_shift_orcicorn():
     import json
-    key_url = "https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json"
 
+    key_url = "https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json"
 
     resp = requests.get(key_url)
     if not resp:
@@ -378,7 +421,7 @@ def parse_shift_orcicorn():
     # Remove expired keys by default (by creating a new dict without them)
     valid_codes = []
     for code_data in data["codes"]:
-        if code_data['expired'] == True:
+        if code_data["expired"] == True:
             continue
         else:
             valid_codes.append(code_data)
@@ -388,16 +431,23 @@ def parse_shift_orcicorn():
         print_banner(data)
 
     for code_data in valid_codes:
-        keys: Iterable[Key]= [Key(**code_data)]
+        keys: Iterable[Key] = [Key(**code_data)]
 
         # 1. special_key_handler
         # 2. known platform
         # 3. shorten game
         keys = list(
-            flatten(map(lambda key: special_key_handler[key.game](key)
-                               if key.game in special_key_handler
-                               else [key]
-                        , keys)))
+            flatten(
+                map(
+                    lambda key: (
+                        special_key_handler[key.game](key)
+                        if key.game in special_key_handler
+                        else [key]
+                    ),
+                    keys,
+                )
+            )
+        )
 
         for key in keys:
             key.set(game=get_short_game_key(key.game))
@@ -405,11 +455,13 @@ def parse_shift_orcicorn():
 
         yield from keys
 
+
 parse_shift_orcicorn.first_parse = True
 
 
 def update_keys():
     from collections import Counter
+
     if not parse_shift_orcicorn.first_parse:
         _L.info("Checking for new keys!")
 
@@ -417,6 +469,13 @@ def update_keys():
     new_keys = [db.insert(key) for key in keys]
 
     counts = Counter(key.game for key in new_keys if key)
+    for game, count in sorted(counts.items()):
+        _L.info(f"Got {count} new keys for {known_games[game]}")
+
+    return keys
+
+
+db = Database()
     for game, count in sorted(counts.items()):
         _L.info(f"Got {count} new keys for {known_games[game]}")
 

--- a/query.py
+++ b/query.py
@@ -307,8 +307,7 @@ class Database(ContextManager):
             return None
         _L.debug(f"== inserting {key.game} Key '{key.code}' for {key.platform} ==")
         self.execute(
-            "INSERT INTO keys(reward, code, platform, game) "
-            "VALUES (?,?,?,?)",
+            "INSERT INTO keys(reward, code, platform, game) " "VALUES (?,?,?,?)",
             (key.reward, key.code, key.platform, key.game),
         )
         self.commit()
@@ -367,7 +366,7 @@ class Database(ContextManager):
         # Mark as redeemed for this key id and platform
         self.execute(
             "INSERT OR IGNORE INTO redeemed_keys (key_id, platform) VALUES (?, ?)",
-            (key.id, key.platform)
+            (key.id, key.platform),
         )
         self.commit()
 
@@ -473,13 +472,3 @@ def update_keys():
         _L.info(f"Got {count} new keys for {known_games[game]}")
 
     return keys
-
-db = Database()
-db = Database()
-    for game, count in sorted(counts.items()):
-        _L.info(f"Got {count} new keys for {known_games[game]}")
-
-    return keys
-
-
-db = Database()


### PR DESCRIPTION
This pull request introduces a major database schema change to how redeemed keys are tracked, moving from a single `redeemed` column in the `keys` table to a new `redeemed_keys` table that tracks redemption status per key and platform. The codebase is also updated to support this new structure, and various code style improvements are made for readability and maintainability. Please note that on first run after upgrading, all keys will be reprocessed to initialize the new database structure, which may take some time.

**Database schema and migration changes:**

* Introduces a new `redeemed_keys` table to track redemption status for each `(key, platform)` combination, and removes the `redeemed` column from the `keys` table. Includes migration logic to transition existing data, with a notice that previously redeemed keys cannot be migrated with platform specificity. (`migrations.py`, `query.py`) [[1]](diffhunk://#diff-d7af58842a76f9c7d30d94d9e2539190b7f4d85a238ef85dc70e4dad3b026884R132-R195) [[2]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L242-L278) [[3]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R330-L307) [[4]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L331-R393)
* Updates all relevant queries and logic to use the new `redeemed_keys` table for checking and setting redemption status. (`query.py`) [[1]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R330-L307) [[2]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L331-R393)

**Documentation:**

* Adds a prominent notice to the `Readme.md` about the database change, explaining the new redemption tracking and expected behavior on upgrade. (`Readme.md`)

**Code quality and style:**

* Refactors and reformats code for improved readability, including more consistent indentation, line breaks, and formatting in `query.py`. [[1]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L25-R34) [[2]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R43) [[3]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L49-R60) [[4]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R75-R100) [[5]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R109) [[6]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L103-R119) [[7]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R146) [[8]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L150-R188) [[9]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L170-R215) [[10]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320R403-R407) [[11]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L381-R423) [[12]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L397-R463)
* Updates the migration registration decorator to accept extra arguments for compatibility. (`migrations.py`)

