### PR TITLE
fix(docker): use exec entrypoint for autoshift startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,5 @@ ENV SHIFT_GAMES='bl4 bl3 blps bl2 bl1' \
 COPY . /autoshift/
 RUN pip install -r ./autoshift/requirements.txt && \
     mkdir -p ./autoshift/data
-CMD if [ -n "${SHIFT_REDEEM}" ]; then \
-        python ./autoshift/auto.py --user ${SHIFT_USER} --pass ${SHIFT_PASS} --redeem ${SHIFT_REDEEM} ${SHIFT_ARGS}; \
-    else \
-        python ./autoshift/auto.py --user ${SHIFT_USER} --pass ${SHIFT_PASS} --games ${SHIFT_GAMES} --platforms ${SHIFT_PLATFORMS} ${SHIFT_ARGS}; \
-    fi
+RUN chmod +x ./autoshift/docker-entrypoint.sh
+ENTRYPOINT ["./autoshift/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${SHIFT_REDEEM:-}" ]; then
+    # Preserve SHIFT_ARGS word splitting while ensuring Python becomes PID 1.
+    # shellcheck disable=SC2086
+    set -- ${SHIFT_ARGS:-}
+    exec python ./autoshift/auto.py --user "${SHIFT_USER:-}" --pass "${SHIFT_PASS:-}" --redeem "${SHIFT_REDEEM}" "$@"
+fi
+
+# shellcheck disable=SC2086
+set -- ${SHIFT_ARGS:-}
+exec python ./autoshift/auto.py --user "${SHIFT_USER:-}" --pass "${SHIFT_PASS:-}" --games "${SHIFT_GAMES}" --platforms "${SHIFT_PLATFORMS}" "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 set -eu
 
+# Preserve SHIFT_ARGS word splitting while ensuring Python becomes PID 1.
+# shellcheck disable=SC2086
+set -- ${SHIFT_ARGS:-}
+
 if [ -n "${SHIFT_REDEEM:-}" ]; then
-    # Preserve SHIFT_ARGS word splitting while ensuring Python becomes PID 1.
-    # shellcheck disable=SC2086
-    set -- ${SHIFT_ARGS:-}
     exec python ./autoshift/auto.py --user "${SHIFT_USER:-}" --pass "${SHIFT_PASS:-}" --redeem "${SHIFT_REDEEM}" "$@"
 fi
 
-# shellcheck disable=SC2086
-set -- ${SHIFT_ARGS:-}
 exec python ./autoshift/auto.py --user "${SHIFT_USER:-}" --pass "${SHIFT_PASS:-}" --games "${SHIFT_GAMES}" --platforms "${SHIFT_PLATFORMS}" "$@"


### PR DESCRIPTION
Replace the shell-form CMD with a dedicated entrypoint script and JSON-form ENTRYPOINT so Python runs as PID 1 and receives OS signals correctly.

Preserve the existing conditional behavior for redeem vs games/platforms and continue passing SHIFT_ARGS through to auto.py.