### PR TITLE
build(python): upgrade Docker runtime to Python 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ notebooks/
 
 # vscode
 *.code-workspace
+.vscode/settings.json
 
 
 # Ignore data folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.14-slim
 
 ENV SHIFT_GAMES='bl4 bl3 blps bl2 bl1' \
     SHIFT_PLATFORMS='epic steam' \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoSHiFt: Automatically redeem Gearbox SHiFT Codes
 
-- **Compatibility:** 3.9+.
+- **Compatibility:** 3.9+ with Docker images tested on Python 3.14.
 - **Platform:** Crossplatform.
 - **Repo:** https://github.com/zarmstrong/autoshift forked from https://github.com/ugoogalizer/autoshift forked from https://github.com/Fabbi/autoshift
 
@@ -211,7 +211,7 @@ This one is the commandline interface you call to use this tool.
 
 # Docker
 
-Available as a docker image based on `python3.10-buster`
+Available as a docker image based on `python:3.14-slim`
 
 ## Docker Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.9"
 APScheduler = "^3.9.1"
 apprise = ">=1,<2"
 beautifulsoup4 = "^4.11.1"
-lxml = "^4.9.0"
+lxml = ">=6,<7"
 requests = "^2.28.0"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 APScheduler>=3.9.1,<4
 apprise>=1,<2
 beautifulsoup4>=4.11.1,<5
-lxml~=4.9
+lxml>=6,<7
 requests~=2.28


### PR DESCRIPTION
Update the Docker base image to Python 3.14 and bump lxml to a Python 3.14-compatible version in both requirements and poetry config.

Refresh the README Docker notes and ignore local VS Code settings in git.