### PR TITLE
ci: upgrade release-please action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Create or update release
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
 
   publish-docker:
     needs: release


### PR DESCRIPTION
## Summary

- upgrade `googleapis/release-please-action` from v4 to v5
- use the action release that natively targets Node.js 24

## Why

GitHub Actions reports that Node.js 20 is deprecated and forcibly runs Release Please v4 on Node.js 24. Release Please v5 updates the action runtime declaration to Node.js 24, removing that compatibility warning.

## Impact

The release workflow keeps the same configuration and outputs. Only the Release Please action runtime version changes.

## Validation

- `git diff --check`
