### PR TITLE
fix: update project author attribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "autoshift"
 version = "2.0.1"
 description = "AutoSHIFt: Automatically redeem Gearbox SHIFt Codes"
 authors = [
-    "Fabian Schweinfurth <github@derfabbi.de>",
     "zarmstrong <git@traffid.com>",
+    "Fabian Schweinfurth <github@derfabbi.de>",
 ]
 license = "GPLv3"
 requires-poetry = ">=2.4,<3.0"

--- a/query.py
+++ b/query.py
@@ -141,7 +141,7 @@ def print_banner(data):
 
     longest_line = max(len(line) for line in lines) + 2
     banner = "\n".join(f"{line: ^{longest_line}}" for line in lines)
-    txt = " autoshift by @Fabbi "
+    txt = " autoshift by @zarmstrong, originally by @Fabbi "
     banner = f"{txt:=^{longest_line}}\n{banner}\n"
     banner += "=" * longest_line
 

--- a/query.py
+++ b/query.py
@@ -139,9 +139,9 @@ def print_banner(data):
     if profile:
         lines.append(f"Profile: {profile}")
 
-    longest_line = max(len(line) for line in lines) + 2
-    banner = "\n".join(f"{line: ^{longest_line}}" for line in lines)
     txt = " autoshift by @zarmstrong, originally by @Fabbi "
+    longest_line = max(max(len(line) for line in lines) + 2, len(txt))
+    banner = "\n".join(f"{line: ^{longest_line}}" for line in lines)
     banner = f"{txt:=^{longest_line}}\n{banner}\n"
     banner += "=" * longest_line
 


### PR DESCRIPTION
## Summary

- list zarmstrong as the primary package author
- update the runtime banner to credit zarmstrong as the current author
- preserve Fabian Schweinfurth (`@Fabbi`) as the original author

## Why

The project banner and package metadata presented the original author as the current primary author. This updates the attribution to reflect current ownership while retaining clear credit for the original work.

## Impact

Users will see the corrected attribution in the startup banner. Package metadata will list the current author first.

## Validation

- `git diff --cached --check`
- `python3 auto.py --help`
